### PR TITLE
feat: add low stock alert widget — Closes #2

### DIFF
--- a/app/Filament/Pages/ShopDashboard.php
+++ b/app/Filament/Pages/ShopDashboard.php
@@ -6,6 +6,7 @@ use App\Enums\OrderStatus;
 use App\Filament\Widgets\CustomerGrowthChart;
 use App\Filament\Widgets\CustomerSegmentsChart;
 use App\Filament\Widgets\FlaggedOrders;
+use App\Filament\Widgets\LowStockAlert;
 use App\Filament\Widgets\OrdersYearOverYearChart;
 use App\Filament\Widgets\OrderValueDistributionChart;
 use App\Filament\Widgets\ProductMarginAnalysisChart;
@@ -70,6 +71,7 @@ class ShopDashboard extends BaseDashboard
             CustomerSegmentsChart::class,
             OrderValueDistributionChart::class,
             ProductMarginAnalysisChart::class,
+            LowStockAlert::class,
         ];
     }
 }

--- a/app/Filament/Widgets/LowStockAlert.php
+++ b/app/Filament/Widgets/LowStockAlert.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Shop\Product;
+use Filament\Support\Enums\FontWeight;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class LowStockAlert extends BaseWidget
+{
+    protected int | string | array $columnSpan = 'full';
+
+    protected static ?int $sort = 8;
+
+    protected static ?string $heading = 'Low Stock Alert';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                Product::query()
+                    ->where('qty', '<', 10)
+                    ->with(['brand', 'productCategories'])
+                    ->orderBy('qty', 'asc')
+            )
+            ->defaultPaginationPageOption(5)
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable()
+                    ->weight(FontWeight::Medium),
+                TextColumn::make('qty')
+                    ->label('Stock')
+                    ->sortable()
+                    ->weight(FontWeight::Bold)
+                    ->color(fn (Product $record): string => $record->qty === 0 ? 'danger' : 'warning'),
+                TextColumn::make('brand.name')
+                    ->label('Brand')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('productCategories.name')
+                    ->label('Categories')
+                    ->badge(),
+                TextColumn::make('price')
+                    ->money('USD')
+                    ->sortable(),
+            ]);
+    }
+}

--- a/config/database.php
+++ b/config/database.php
@@ -59,7 +59,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (defined('Pdo\Mysql::ATTR_SSL_CA') ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 


### PR DESCRIPTION
## Summary
- Add **LowStockAlert** table widget to Shop dashboard showing products with stock < 10
- Zero-stock products highlighted in red, low-stock (1-9) in yellow
- Displays product name, stock count, brand, categories, and price
- Fix PHP 8.5 `PDO::MYSQL_ATTR_SSL_CA` deprecation warning

## Test plan
- [ ] Go to `localhost:8080/shop` and scroll to the bottom
- [ ] Verify "Low Stock Alert" table shows products with qty < 10
- [ ] Verify zero-stock products appear in red
- [ ] Verify search and sort work on the widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)