### PR TITLE
feat: add product table summaries — Closes #D1

### DIFF
--- a/app/Filament/Resources/Shop/Products/Tables/ProductsTable.php
+++ b/app/Filament/Resources/Shop/Products/Tables/ProductsTable.php
@@ -17,6 +17,9 @@ use Filament\Support\Enums\Width;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
+use Filament\Tables\Columns\Summarizers\Average;
+use Filament\Tables\Columns\Summarizers\Count;
+use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\FiltersLayout;
 use Filament\Tables\Filters\QueryBuilder;
@@ -40,7 +43,8 @@ class ProductsTable
                 TextColumn::make('name')
                     ->searchable()
                     ->sortable()
-                    ->weight(FontWeight::Medium),
+                    ->weight(FontWeight::Medium)
+                    ->summarize(Count::make('count')),
 
                 TextColumn::make('brand.name')
                     ->searchable()
@@ -54,7 +58,8 @@ class ProductsTable
 
                 TextColumn::make('price')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->summarize(Average::make('average')->money('usd')),
 
                 TextColumn::make('sku')
                     ->label('SKU')
@@ -66,7 +71,8 @@ class ProductsTable
                     ->label('Quantity')
                     ->searchable()
                     ->sortable()
-                    ->toggleable(),
+                    ->toggleable()
+                    ->summarize(Sum::make('sum')),
 
                 TextColumn::make('security_stock')
                     ->searchable()

--- a/tests/Filament/Resources/Shop/Products/Pages/ListProductsTest.php
+++ b/tests/Filament/Resources/Shop/Products/Pages/ListProductsTest.php
@@ -86,3 +86,29 @@ it('has query builder filter', function () {
     Livewire::test(ListProducts::class)
         ->assertTableFilterExists('queryBuilder');
 });
+
+it('shows product count summarizer on name column', function () {
+    Product::factory()->count(3)->create();
+
+    Livewire::test(ListProducts::class)
+        ->assertTableColumnSummarizerExists('name', 'count')
+        ->assertTableColumnSummarySet('name', 'count', 3);
+});
+
+it('shows average price summarizer on price column', function () {
+    Product::factory()->create(['price' => 100]);
+    Product::factory()->create(['price' => 200]);
+
+    Livewire::test(ListProducts::class)
+        ->assertTableColumnSummarizerExists('price', 'average')
+        ->assertTableColumnSummarySet('price', 'average', 150);
+});
+
+it('shows total stock summarizer on qty column', function () {
+    Product::factory()->create(['qty' => 10]);
+    Product::factory()->create(['qty' => 25]);
+
+    Livewire::test(ListProducts::class)
+        ->assertTableColumnSummarizerExists('qty', 'sum')
+        ->assertTableColumnSummarySet('qty', 'sum', 35);
+});


### PR DESCRIPTION
## Summary
- Add `Count` summarizer to the `name` column — shows total product count in the table footer
- Add `Average` summarizer to the `price` column — shows average price (USD formatted)
- Add `Sum` summarizer to the `qty` column — shows total stock across all products

## Test plan
- [ ] Go to `localhost:8000/shop/products`
- [ ] Scroll to the bottom of the table — footer row shows: product count, average price ($), total stock
- [ ] Apply a filter (e.g. filter by brand) — footer values update to reflect filtered results

🤖 Generated with [Claude Code](https://claude.com/claude-code)