### PR TITLE
feat: add birthday reminders to HR

### DIFF
--- a/app/Console/Commands/HrBirthdays.php
+++ b/app/Console/Commands/HrBirthdays.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\HR\Employee;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class HrBirthdays extends Command
+{
+    protected $signature = 'hr:birthdays {--days=7 : Number of days ahead to look}';
+
+    protected $description = 'List employees with upcoming birthdays.';
+
+    public function handle(): int
+    {
+        $days = (int) $this->option('days');
+
+        $upcoming = Employee::query()
+            ->whereNotNull('date_of_birth')
+            ->where('is_active', true)
+            ->get(['id', 'name', 'job_title', 'date_of_birth'])
+            ->map(function (Employee $employee) use ($days): ?array {
+                $birthday = Carbon::parse($employee->date_of_birth)->setYear(now()->year);
+
+                if ($birthday->lt(now()->startOfDay())) {
+                    $birthday->addYear();
+                }
+
+                if ($birthday->gt(now()->addDays($days)->endOfDay())) {
+                    return null;
+                }
+
+                $daysUntil = (int) now()->startOfDay()->diffInDays($birthday->startOfDay());
+                $turningAge = Carbon::parse($employee->date_of_birth)->age + 1;
+                $isToday = $daysUntil === 0;
+
+                return [
+                    'name' => $isToday ? $employee->name . ' 🎂' : $employee->name,
+                    'job_title' => $employee->job_title,
+                    'birthday' => $birthday->format('F j'),
+                    'turning' => $turningAge . ' years old',
+                    'days_away' => $isToday ? 'Today! 🎂' : $daysUntil . ' day' . ($daysUntil === 1 ? '' : 's'),
+                ];
+            })
+            ->filter()
+            ->sortBy('days_away')
+            ->values();
+
+        if ($upcoming->isEmpty()) {
+            $this->info("No upcoming birthdays in the next {$days} days.");
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Upcoming birthdays in the next {$days} days:");
+        $this->newLine();
+
+        $this->table(
+            ['Name', 'Job Title', 'Birthday', 'Turning', 'Days Away'],
+            $upcoming->toArray(),
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Filament/Pages/HrDashboard.php
+++ b/app/Filament/Pages/HrDashboard.php
@@ -5,6 +5,7 @@ namespace App\Filament\Pages;
 use App\Filament\Widgets\BudgetBurnRateChart;
 use App\Filament\Widgets\DepartmentLeaveLoadChart;
 use App\Filament\Widgets\ProjectHealthChart;
+use App\Filament\Widgets\UpcomingBirthdaysWidget;
 use App\Filament\Widgets\UtilizationRateChart;
 use App\Filament\Widgets\WorkforceInsightsStats;
 use BackedEnum;
@@ -24,6 +25,7 @@ class HrDashboard extends BaseDashboard
     public function getWidgets(): array
     {
         return [
+            UpcomingBirthdaysWidget::class,
             WorkforceInsightsStats::class,
             DepartmentLeaveLoadChart::class,
             ProjectHealthChart::class,

--- a/app/Filament/Widgets/UpcomingBirthdaysWidget.php
+++ b/app/Filament/Widgets/UpcomingBirthdaysWidget.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\HR\Employee;
+use Filament\Support\Enums\FontWeight;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+class UpcomingBirthdaysWidget extends BaseWidget
+{
+    protected int | string | array $columnSpan = 'full';
+
+    protected static ?int $sort = 7;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query($this->upcomingBirthdaysQuery())
+            ->defaultPaginationPageOption(5)
+            ->heading('Upcoming Birthdays')
+            ->description('Employees with birthdays in the next 7 days')
+            ->emptyStateHeading('No upcoming birthdays')
+            ->emptyStateIcon(Heroicon::Cake)
+            ->columns([
+                TextColumn::make('name')
+                    ->weight(FontWeight::Medium)
+                    ->searchable()
+                    ->formatStateUsing(function (Employee $record): string {
+                        $birthday = Carbon::parse($record->date_of_birth)->setYear(now()->year);
+
+                        if ($birthday->lt(now()->startOfDay())) {
+                            $birthday->addYear();
+                        }
+
+                        $isToday = now()->startOfDay()->diffInDays($birthday->startOfDay()) === 0;
+
+                        return $isToday ? $record->name . ' 🎂' : $record->name;
+                    }),
+
+                TextColumn::make('date_of_birth')
+                    ->label('Birthday')
+                    ->date('F j')
+                    ->sortable(),
+
+                TextColumn::make('age')
+                    ->label('Turning')
+                    ->state(fn (Employee $record): string => Carbon::parse($record->date_of_birth)->age + 1 . ' years old')
+                    ->color('gray'),
+
+                TextColumn::make('days_until_birthday')
+                    ->label('Days Away')
+                    ->state(function (Employee $record): string {
+                        $birthday = Carbon::parse($record->date_of_birth)->setYear(now()->year);
+
+                        if ($birthday->lt(now()->startOfDay())) {
+                            $birthday->addYear();
+                        }
+
+                        $days = (int) now()->startOfDay()->diffInDays($birthday->startOfDay());
+
+                        return $days === 0 ? 'Today! 🎂' : $days . ' day' . ($days === 1 ? '' : 's');
+                    })
+                    ->badge()
+                    ->color(fn (Employee $record): string => $this->getBadgeColor($record)),
+
+                TextColumn::make('job_title')
+                    ->toggleable(isToggledHiddenByDefault: true),
+
+                TextColumn::make('department.name')
+                    ->toggleable(),
+            ]);
+    }
+
+    /** @return Builder<Employee> */
+    private function upcomingBirthdaysQuery(): Builder
+    {
+        $ids = Employee::query()
+            ->whereNotNull('date_of_birth')
+            ->where('is_active', true)
+            ->get(['id', 'date_of_birth'])
+            ->filter(function (Employee $employee): bool {
+                $birthday = Carbon::parse($employee->date_of_birth)->setYear(now()->year);
+
+                if ($birthday->lt(now()->startOfDay())) {
+                    $birthday->addYear();
+                }
+
+                return $birthday->lte(now()->addDays(7)->endOfDay());
+            })
+            ->pluck('id')
+            ->all();
+
+        return Employee::query()->whereIn('id', $ids)->with('department');
+    }
+
+    private function getBadgeColor(Employee $record): string
+    {
+        $birthday = Carbon::parse($record->date_of_birth)->setYear(now()->year);
+
+        if ($birthday->lt(now()->startOfDay())) {
+            $birthday->addYear();
+        }
+
+        $days = (int) now()->startOfDay()->diffInDays($birthday->startOfDay());
+
+        return match (true) {
+            $days === 0 => 'success',
+            $days <= 3 => 'warning',
+            default => 'info',
+        };
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,8 +18,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/tests/Filament/Commands/HrBirthdaysCommandTest.php
+++ b/tests/Filament/Commands/HrBirthdaysCommandTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\HR\Employee;
+
+it('prints upcoming birthdays', function () {
+    Employee::factory()->create([
+        'is_active' => true,
+        'date_of_birth' => now()->subYears(30)->addDays(2),
+    ]);
+
+    $this->artisan('hr:birthdays')
+        ->assertSuccessful();
+});
+
+it('shows no upcoming birthdays message when none exist', function () {
+    $this->artisan('hr:birthdays')
+        ->expectsOutputToContain('No upcoming birthdays')
+        ->assertSuccessful();
+});
+
+it('respects the --days option', function () {
+    $withinRange = Employee::factory()->create([
+        'is_active' => true,
+        'name' => 'Alice Within',
+        'date_of_birth' => now()->subYears(25)->addDays(3),
+    ]);
+
+    $outsideRange = Employee::factory()->create([
+        'is_active' => true,
+        'name' => 'Bob Outside',
+        'date_of_birth' => now()->subYears(25)->addDays(15),
+    ]);
+
+    $this->artisan('hr:birthdays --days=5')
+        ->expectsOutputToContain($withinRange->name)
+        ->doesntExpectOutputToContain($outsideRange->name)
+        ->assertSuccessful();
+});
+
+it('does not show inactive employees', function () {
+    $inactive = Employee::factory()->create([
+        'is_active' => false,
+        'name' => 'Inactive Employee',
+        'date_of_birth' => now()->subYears(25)->addDays(1),
+    ]);
+
+    $this->artisan('hr:birthdays')
+        ->doesntExpectOutputToContain($inactive->name)
+        ->assertSuccessful();
+});

--- a/tests/Filament/Widgets/UpcomingBirthdaysWidgetTest.php
+++ b/tests/Filament/Widgets/UpcomingBirthdaysWidgetTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Filament\Widgets\UpcomingBirthdaysWidget;
+use App\Models\HR\Employee;
+use Livewire\Livewire;
+
+it('renders the upcoming birthdays widget', function () {
+    Employee::factory()->create([
+        'is_active' => true,
+        'date_of_birth' => now()->subYears(30)->addDays(3),
+    ]);
+
+    Livewire::test(UpcomingBirthdaysWidget::class)
+        ->assertOk();
+});
+
+it('shows employees with birthdays in the next 7 days', function () {
+    $upcoming = Employee::factory()->create([
+        'is_active' => true,
+        'date_of_birth' => now()->subYears(25)->addDays(2),
+    ]);
+
+    $notUpcoming = Employee::factory()->create([
+        'is_active' => true,
+        'date_of_birth' => now()->subYears(25)->addDays(10),
+    ]);
+
+    Livewire::test(UpcomingBirthdaysWidget::class)
+        ->assertCanSeeTableRecords([$upcoming])
+        ->assertCanNotSeeTableRecords([$notUpcoming]);
+});
+
+it('does not show inactive employees', function () {
+    $inactive = Employee::factory()->create([
+        'is_active' => false,
+        'date_of_birth' => now()->subYears(25)->addDays(1),
+    ]);
+
+    Livewire::test(UpcomingBirthdaysWidget::class)
+        ->assertCanNotSeeTableRecords([$inactive]);
+});
+
+it('shows empty state when no upcoming birthdays', function () {
+    Livewire::test(UpcomingBirthdaysWidget::class)
+        ->assertSee('No upcoming birthdays');
+});


### PR DESCRIPTION
## Summary
- Add **Upcoming Birthdays** widget on the HR Dashboard — shows employees with birthdays in the next 7 days
- Cake emoji 🎂 next to today's birthdays, age shown as "Turning X years old"
- Add `php artisan hr:birthdays` Artisan command to print the same list in the terminal
- Fix `phpunit.xml` to use in-memory SQLite so tests never wipe the dev database

## Test plan
- [x] Run `php artisan migrate`
- [x] Edit an employee → Personal tab → set Date of Birth to this week
- [x] Check HR Dashboard → Upcoming Birthdays widget shows the employee
- [x] Run `php artisan hr:birthdays` → same list printed in terminal
- [x] Set birthday to today → 🎂 appears next to name in both widget and terminal
- [x] All 488 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)