### PR TITLE
feat: add birthday reminders, advanced leave management, and tiered customer loyalty system

### DIFF
--- a/app/Console/Commands/HrBirthdays.php
+++ b/app/Console/Commands/HrBirthdays.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\HR\Employee;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class HrBirthdays extends Command
+{
+    protected $signature = 'hr:birthdays';
+
+    protected $description = 'List active employees with birthdays in the next 7 days.';
+
+    public function handle(): int
+    {
+        $dates = collect(range(0, 7))
+            ->map(fn (int $i): string => now()->addDays($i)->format('m-d'))
+            ->toArray();
+
+        $formatExpr = $this->birthdayFormatExpression();
+
+        $employees = Employee::query()
+            ->whereNotNull('date_of_birth')
+            ->where('is_active', true)
+            ->whereIn(DB::raw($formatExpr), $dates)
+            ->with('department')
+            ->orderByRaw(
+                "CASE WHEN {$formatExpr} >= {$this->todayFormatExpression()} THEN 0 ELSE 1 END,
+                 {$formatExpr} ASC"
+            )
+            ->get();
+
+        if ($employees->isEmpty()) {
+            $this->info('No upcoming birthdays in the next 7 days.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['Name', 'Department', 'Birthday', 'Turning', 'Days Away'],
+            $employees->map(function (Employee $employee): array {
+                $today = now()->startOfDay();
+                $birthday = $employee->date_of_birth->copy()->year($today->year);
+
+                if ($birthday->lt($today)) {
+                    $birthday->addYear();
+                }
+
+                $days = (int) $today->diffInDays($birthday);
+                $turningAge = $birthday->year - $employee->date_of_birth->year;
+
+                return [
+                    $employee->name,
+                    $employee->department?->name ?? '—',
+                    $employee->date_of_birth->format('M j'),
+                    $turningAge . ' yrs',
+                    $days === 0 ? 'Today!' : 'In ' . $days . ($days === 1 ? ' day' : ' days'),
+                ];
+            })->all()
+        );
+
+        return self::SUCCESS;
+    }
+
+    private function birthdayFormatExpression(): string
+    {
+        return DB::getDriverName() === 'sqlite'
+            ? "strftime('%m-%d', date_of_birth)"
+            : "TO_CHAR(date_of_birth, 'MM-DD')";
+    }
+
+    private function todayFormatExpression(): string
+    {
+        return DB::getDriverName() === 'sqlite'
+            ? "strftime('%m-%d', 'now')"
+            : "TO_CHAR(CURRENT_DATE, 'MM-DD')";
+    }
+}

--- a/app/Enums/CustomerTier.php
+++ b/app/Enums/CustomerTier.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+use Filament\Support\Icons\Heroicon;
+
+enum CustomerTier: string implements HasColor, HasIcon, HasLabel
+{
+    case New = 'new';
+
+    case Silver = 'silver';
+
+    case Gold = 'gold';
+
+    public static function fromOrderCount(int $count): self
+    {
+        return match (true) {
+            $count >= 6 => self::Gold,
+            $count >= 2 => self::Silver,
+            default => self::New,
+        };
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::New => 'New',
+            self::Silver => 'Silver',
+            self::Gold => 'Gold',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::New => 'info',
+            self::Silver => 'gray',
+            self::Gold => 'warning',
+        };
+    }
+
+    public function getIcon(): Heroicon
+    {
+        return match ($this) {
+            self::New => Heroicon::Sparkles,
+            self::Silver => Heroicon::Star,
+            self::Gold => Heroicon::Trophy,
+        };
+    }
+}

--- a/app/Filament/Pages/HrDashboard.php
+++ b/app/Filament/Pages/HrDashboard.php
@@ -5,6 +5,7 @@ namespace App\Filament\Pages;
 use App\Filament\Widgets\BudgetBurnRateChart;
 use App\Filament\Widgets\DepartmentLeaveLoadChart;
 use App\Filament\Widgets\ProjectHealthChart;
+use App\Filament\Widgets\UpcomingBirthdaysWidget;
 use App\Filament\Widgets\UtilizationRateChart;
 use App\Filament\Widgets\WorkforceInsightsStats;
 use BackedEnum;
@@ -25,6 +26,7 @@ class HrDashboard extends BaseDashboard
     {
         return [
             WorkforceInsightsStats::class,
+            UpcomingBirthdaysWidget::class,
             DepartmentLeaveLoadChart::class,
             ProjectHealthChart::class,
             UtilizationRateChart::class,

--- a/app/Filament/Pages/RewardsDashboard.php
+++ b/app/Filament/Pages/RewardsDashboard.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Enums\CustomerTier;
+use App\Models\Shop\Customer;
+use App\Services\Shop\CustomerLoyaltyService;
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Select;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Enums\FontWeight;
+use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Builder;
+use UnitEnum;
+
+class RewardsDashboard extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected string $view = 'filament.pages.rewards-dashboard';
+
+    protected static string $routePath = 'rewards';
+
+    protected static ?string $title = 'Rewards Dashboard';
+
+    protected static string | BackedEnum | null $navigationIcon = Heroicon::OutlinedGift;
+
+    protected static UnitEnum | string | null $navigationGroup = 'Shop';
+
+    protected static ?int $navigationSort = 5;
+
+    public function getTitle(): string | Htmlable
+    {
+        return 'Rewards Dashboard';
+    }
+
+    public function table(Table $table): Table
+    {
+        $service = app(CustomerLoyaltyService::class);
+        $vipIds = $service->getTop5GoldCustomerIds();
+
+        return $table
+            ->query(
+                Customer::query()->withCount('orders')->withCount('discountCodes')
+            )
+            ->defaultSort('orders_count', 'desc')
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable()
+                    ->weight(FontWeight::Medium),
+
+                TextColumn::make('email')
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(),
+
+                TextColumn::make('orders_count')
+                    ->label('Total Orders')
+                    ->sortable()
+                    ->badge()
+                    ->color('primary'),
+
+                TextColumn::make('loyalty_tier')
+                    ->label('Tier')
+                    ->badge()
+                    ->state(fn (Customer $record): string => CustomerTier::fromOrderCount($record->orders_count ?? 0)->getLabel())
+                    ->color(fn (Customer $record): string => CustomerTier::fromOrderCount($record->orders_count ?? 0)->getColor())
+                    ->icon(fn (Customer $record): Heroicon => CustomerTier::fromOrderCount($record->orders_count ?? 0)->getIcon()),
+
+                TextColumn::make('discount_codes_count')
+                    ->label('Codes Generated')
+                    ->sortable()
+                    ->badge()
+                    ->color('gray'),
+            ])
+            ->filters([
+                SelectFilter::make('loyalty_tier')
+                    ->label('Tier')
+                    ->options([
+                        'new' => 'New (1 order)',
+                        'silver' => 'Silver (2–5 orders)',
+                        'gold' => 'Gold (6+ orders)',
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return match ($data['value'] ?? null) {
+                            'new' => $query->has('orders', '=', 1),
+                            'silver' => $query->has('orders', '>=', 2)->has('orders', '<=', 5),
+                            'gold' => $query->has('orders', '>=', 6),
+                            default => $query,
+                        };
+                    }),
+            ])
+            ->recordActions([
+                Action::make('reward_vip')
+                    ->label('Reward VIP')
+                    ->icon(Heroicon::Trophy)
+                    ->color('warning')
+                    ->modalWidth(Width::Medium)
+                    ->modalSubmitActionLabel('Generate Code')
+                    ->visible(fn (Customer $record): bool => $vipIds->contains($record->id))
+                    ->schema([
+                        Select::make('discount_percentage')
+                            ->label('Discount percentage')
+                            ->options([
+                                10 => '10% — Standard VIP',
+                                15 => '15% — Premium VIP',
+                                20 => '20% — Elite VIP',
+                            ])
+                            ->required(),
+                        Placeholder::make('note')
+                            ->label('')
+                            ->content('A unique coupon code (e.g. VIP20-XXXX) will be generated and tied to this customer.'),
+                    ])
+                    ->action(function (Customer $record, array $data) use ($service): void {
+                        $code = $service->generateVipCode($record, $data['discount_percentage']);
+
+                        Notification::make()
+                            ->title("VIP code generated: {$code->code}")
+                            ->body("{$data['discount_percentage']}% discount for {$record->name}")
+                            ->success()
+                            ->send();
+                    }),
+            ]);
+    }
+}

--- a/app/Filament/Resources/HR/Employees/Schemas/EmployeeForm.php
+++ b/app/Filament/Resources/HR/Employees/Schemas/EmployeeForm.php
@@ -116,6 +116,16 @@ class EmployeeForm
                                         EmploymentType::Intern->value,
                                     ])),
 
+                                TextInput::make('leave_allowance')
+                                    ->label('Annual Leave Allowance (days)')
+                                    ->numeric()
+                                    ->integer()
+                                    ->minValue(0)
+                                    ->maxValue(365)
+                                    ->default(20)
+                                    ->required()
+                                    ->suffix('days'),
+
                                 Toggle::make('is_active')
                                     ->label('Active')
                                     ->default(true)

--- a/app/Filament/Resources/HR/LeaveRequests/Tables/LeaveRequestsTable.php
+++ b/app/Filament/Resources/HR/LeaveRequests/Tables/LeaveRequestsTable.php
@@ -20,6 +20,7 @@ use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 class LeaveRequestsTable
@@ -54,12 +55,59 @@ class LeaveRequestsTable
                     ->sortable()
                     ->summarize(Sum::make()),
 
+                TextColumn::make('department_conflicts')
+                    ->label('Dept. Conflicts')
+                    ->badge()
+                    ->color('warning')
+                    ->icon(Heroicon::ExclamationTriangle)
+                    ->state(function (LeaveRequest $record): ?string {
+                        if ($record->employee === null || $record->employee->department_id === null) {
+                            return null;
+                        }
+
+                        $count = LeaveRequest::query()
+                            ->where('id', '!=', $record->id)
+                            ->whereIn('status', [LeaveStatus::Approved->value, LeaveStatus::Pending->value])
+                            ->whereHas('employee', fn (Builder $q) => $q->where('department_id', $record->employee->department_id))
+                            ->where(function (Builder $q) use ($record): void {
+                                $q->whereBetween('start_date', [$record->start_date, $record->end_date])
+                                    ->orWhereBetween('end_date', [$record->start_date, $record->end_date])
+                                    ->orWhere(function (Builder $q) use ($record): void {
+                                        $q->where('start_date', '<=', $record->start_date)
+                                            ->where('end_date', '>=', $record->end_date);
+                                    });
+                            })
+                            ->count();
+
+                        if ($count === 0) {
+                            return null;
+                        }
+
+                        $dept = $record->employee->department->name ?? 'dept';
+
+                        return "{$count} other" . ($count > 1 ? 's' : '') . " off in {$dept}";
+                    }),
+
                 TextColumn::make('approver.name')
                     ->toggleable()
                     ->toggledHiddenByDefault()
                     ->placeholder('Not assigned'),
             ])
             ->defaultSort('start_date', 'desc')
+            ->recordClasses(function (LeaveRequest $record): ?string {
+                if ($record->employee === null) {
+                    return null;
+                }
+
+                $usedDays = $record->employee->usedLeaveDaysThisYear();
+                $allowance = $record->employee->leave_allowance;
+
+                if ($usedDays >= $allowance) {
+                    return 'bg-danger-50 dark:bg-danger-950/50';
+                }
+
+                return null;
+            })
             ->recordActions([
                 ActionGroup::make([
                     Action::make('approve')

--- a/app/Filament/Resources/Shop/Orders/Tables/OrdersTable.php
+++ b/app/Filament/Resources/Shop/Orders/Tables/OrdersTable.php
@@ -2,17 +2,23 @@
 
 namespace App\Filament\Resources\Shop\Orders\Tables;
 
+use App\Enums\CustomerTier;
 use App\Enums\OrderStatus;
 use App\Models\Shop\Order;
+use App\Services\Shop\CustomerLoyaltyService;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Support\Enums\FontWeight;
+use Filament\Support\Enums\Width;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\Summarizers\Sum;
 use Filament\Tables\Columns\TextColumn;
@@ -28,37 +34,69 @@ class OrdersTable
     public static function configure(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->with([
+                'customer' => fn ($q) => $q->withCount('orders'),
+            ]))
             ->columns([
                 TextColumn::make('number')
                     ->searchable()
                     ->sortable()
                     ->weight(FontWeight::Medium),
+
                 TextColumn::make('customer.name')
                     ->searchable()
                     ->sortable()
                     ->toggleable(),
+
+                TextColumn::make('customer_tier')
+                    ->label('Loyalty Tier')
+                    ->badge()
+                    ->state(function (Order $record): ?string {
+                        if ($record->customer === null) {
+                            return null;
+                        }
+
+                        return CustomerTier::fromOrderCount($record->customer->orders_count ?? 0)->getLabel();
+                    })
+                    ->color(function (Order $record): string {
+                        if ($record->customer === null) {
+                            return 'gray';
+                        }
+
+                        return CustomerTier::fromOrderCount($record->customer->orders_count ?? 0)->getColor();
+                    })
+                    ->icon(function (Order $record): ?Heroicon {
+                        if ($record->customer === null) {
+                            return null;
+                        }
+
+                        return CustomerTier::fromOrderCount($record->customer->orders_count ?? 0)->getIcon();
+                    }),
+
                 TextColumn::make('status')
                     ->badge(),
+
                 TextColumn::make('currency')
                     ->searchable()
                     ->sortable()
                     ->toggleable(),
+
                 TextColumn::make('total_price')
                     ->searchable()
                     ->sortable()
                     ->summarize([
-                        Sum::make()
-                            ->money(),
+                        Sum::make()->money(),
                     ]),
+
                 TextColumn::make('shipping_price')
                     ->label('Shipping cost')
                     ->searchable()
                     ->sortable()
                     ->toggleable()
                     ->summarize([
-                        Sum::make()
-                            ->money(),
+                        Sum::make()->money(),
                     ]),
+
                 TextColumn::make('created_at')
                     ->label('Order date')
                     ->date()
@@ -99,7 +137,118 @@ class OrdersTable
                     }),
             ])
             ->recordActions([
+                Action::make('apply_welcome_discount')
+                    ->label('Apply 10% Welcome')
+                    ->icon(Heroicon::Gift)
+                    ->button()
+                    ->color('success')
+                    ->modalWidth(Width::Medium)
+                    ->modalSubmitActionLabel('Apply Discount')
+                    ->visible(function (Order $record): bool {
+                        if ($record->customer === null || $record->discount_applied) {
+                            return false;
+                        }
+
+                        return CustomerTier::fromOrderCount($record->customer->orders_count ?? 0) === CustomerTier::New;
+                    })
+                    ->fillForm(fn (Order $record): array => [
+                        'current_price' => number_format((float) $record->total_price, 2),
+                        'discounted_price' => number_format(
+                            app(CustomerLoyaltyService::class)->previewWelcomeDiscount($record),
+                            2
+                        ),
+                    ])
+                    ->schema([
+                        TextInput::make('current_price')
+                            ->label('Current price')
+                            ->prefix('$')
+                            ->disabled()
+                            ->dehydrated(false),
+                        TextInput::make('discounted_price')
+                            ->label('Price after 10% discount')
+                            ->prefix('$')
+                            ->disabled()
+                            ->dehydrated(false),
+                    ])
+                    ->action(function (Order $record): void {
+                        app(CustomerLoyaltyService::class)->applyWelcomeDiscount($record);
+
+                        Notification::make()
+                            ->title('10% welcome discount applied')
+                            ->success()
+                            ->send();
+                    }),
+
+                Action::make('reward_new')
+                    ->label('Give Welcome Code')
+                    ->icon(Heroicon::Sparkles)
+                    ->button()
+                    ->color('info')
+                    ->modalWidth(Width::Medium)
+                    ->modalSubmitActionLabel('Generate Code')
+                    ->visible(function (Order $record): bool {
+                        if ($record->customer === null) {
+                            return false;
+                        }
+
+                        return CustomerTier::fromOrderCount($record->customer->orders_count ?? 0) === CustomerTier::New;
+                    })
+                    ->schema([
+                        Placeholder::make('note')
+                            ->label('')
+                            ->content('A unique 10% welcome coupon code (e.g. WELCOME-XXXX) will be generated and tied to this customer.'),
+                    ])
+                    ->action(function (Order $record): void {
+                        $code = app(CustomerLoyaltyService::class)
+                            ->generateWelcomeCode($record->customer);
+
+                        Notification::make()
+                            ->title("Welcome code generated: {$code->code}")
+                            ->body("10% discount for {$record->customer->name}")
+                            ->success()
+                            ->send();
+                    }),
+
+                Action::make('reward_vip')
+                    ->label('Reward VIP')
+                    ->icon(Heroicon::Trophy)
+                    ->button()
+                    ->color('warning')
+                    ->modalWidth(Width::Medium)
+                    ->modalSubmitActionLabel('Generate Code')
+                    ->visible(function (Order $record): bool {
+                        if ($record->customer === null) {
+                            return false;
+                        }
+
+                        return app(CustomerLoyaltyService::class)->isVipCustomer($record->customer);
+                    })
+                    ->schema([
+                        Select::make('discount_percentage')
+                            ->label('Discount percentage')
+                            ->options([
+                                10 => '10% — Standard VIP',
+                                15 => '15% — Premium VIP',
+                                20 => '20% — Elite VIP',
+                            ])
+                            ->required(),
+                        Placeholder::make('note')
+                            ->label('')
+                            ->content('A unique coupon code (e.g. VIP20-XXXX) will be generated and tied to this customer.'),
+                    ])
+                    ->action(function (Order $record, array $data): void {
+                        $code = app(CustomerLoyaltyService::class)
+                            ->generateVipCode($record->customer, $data['discount_percentage']);
+
+                        Notification::make()
+                            ->title("VIP code generated: {$code->code}")
+                            ->body("{$data['discount_percentage']}% discount for {$record->customer->name}")
+                            ->success()
+                            ->send();
+                    }),
+
                 ActionGroup::make([
+
                     Action::make('process')
                         ->icon(Heroicon::ArrowPath)
                         ->color('warning')
@@ -112,6 +261,7 @@ class OrdersTable
                                 ->success()
                                 ->send();
                         }),
+
                     Action::make('ship')
                         ->icon(Heroicon::Truck)
                         ->color('success')
@@ -150,6 +300,7 @@ class OrdersTable
                                 ->success()
                                 ->send();
                         }),
+
                     Action::make('deliver')
                         ->icon(Heroicon::CheckBadge)
                         ->color('success')
@@ -163,7 +314,9 @@ class OrdersTable
                                 ->success()
                                 ->send();
                         }),
+
                     EditAction::make(),
+
                     Action::make('cancel')
                         ->icon(Heroicon::XCircle)
                         ->color('danger')
@@ -178,6 +331,7 @@ class OrdersTable
                                 ->danger()
                                 ->send();
                         }),
+
                     DeleteAction::make()
                         ->action(function (): void {
                             Notification::make()

--- a/app/Filament/Widgets/UpcomingBirthdaysWidget.php
+++ b/app/Filament/Widgets/UpcomingBirthdaysWidget.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\HR\Employee;
+use Filament\Support\Enums\FontWeight;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Support\Facades\DB;
+
+class UpcomingBirthdaysWidget extends BaseWidget
+{
+    protected static ?string $heading = 'Upcoming Birthdays';
+
+    protected static ?string $description = 'Active employees with birthdays in the next 7 days';
+
+    protected int | string | array $columnSpan = 'full';
+
+    protected static ?int $sort = 13;
+
+    protected bool $paginated = false;
+
+    public function table(Table $table): Table
+    {
+        $dates = collect(range(0, 7))
+            ->map(fn (int $i): string => now()->addDays($i)->format('m-d'))
+            ->toArray();
+
+        $formatExpr = $this->birthdayFormatExpression();
+
+        return $table
+            ->query(
+                Employee::query()
+                    ->whereNotNull('date_of_birth')
+                    ->where('is_active', true)
+                    ->whereIn(DB::raw($formatExpr), $dates)
+                    ->with('department')
+                    ->orderByRaw(
+                        "CASE WHEN {$formatExpr} >= {$this->todayFormatExpression()} THEN 0 ELSE 1 END,
+                         {$formatExpr} ASC"
+                    )
+            )
+            ->columns([
+                TextColumn::make('name')
+                    ->weight(FontWeight::Medium)
+                    ->searchable(),
+
+                TextColumn::make('department.name')
+                    ->label('Department')
+                    ->placeholder('—'),
+
+                TextColumn::make('birthday')
+                    ->label('Birthday')
+                    ->state(fn (Employee $record): string => $record->date_of_birth->format('M j')),
+
+                TextColumn::make('turning')
+                    ->label('Turning')
+                    ->state(function (Employee $record): string {
+                        $today = now()->startOfDay();
+                        $birthday = $record->date_of_birth->copy()->year($today->year);
+
+                        if ($birthday->lt($today)) {
+                            $birthday->addYear();
+                        }
+
+                        return ($birthday->year - $record->date_of_birth->year) . ' yrs';
+                    }),
+
+                TextColumn::make('when')
+                    ->label('When')
+                    ->state(function (Employee $record): string {
+                        $today = now()->startOfDay();
+                        $birthday = $record->date_of_birth->copy()->year($today->year);
+
+                        if ($birthday->lt($today)) {
+                            $birthday->addYear();
+                        }
+
+                        $days = (int) $today->diffInDays($birthday);
+
+                        return $days === 0 ? 'Today!' : 'In ' . $days . ($days === 1 ? ' day' : ' days');
+                    })
+                    ->weight(FontWeight::Bold),
+            ])
+            ->emptyStateHeading('No upcoming birthdays')
+            ->emptyStateDescription('No active employees have birthdays in the next 7 days.');
+    }
+
+    private function birthdayFormatExpression(): string
+    {
+        return DB::getDriverName() === 'sqlite'
+            ? "strftime('%m-%d', date_of_birth)"
+            : "TO_CHAR(date_of_birth, 'MM-DD')";
+    }
+
+    private function todayFormatExpression(): string
+    {
+        return DB::getDriverName() === 'sqlite'
+            ? "strftime('%m-%d', 'now')"
+            : "TO_CHAR(CURRENT_DATE, 'MM-DD')";
+    }
+}

--- a/app/Models/HR/Employee.php
+++ b/app/Models/HR/Employee.php
@@ -32,9 +32,18 @@ class Employee extends Model
         'metadata' => 'array',
         'salary' => 'decimal:2',
         'hourly_rate' => 'decimal:2',
+        'leave_allowance' => 'integer',
         'date_of_birth' => 'date',
         'hire_date' => 'date',
     ];
+
+    public function usedLeaveDaysThisYear(): float
+    {
+        return (float) $this->leaveRequests()
+            ->whereYear('start_date', now()->year)
+            ->whereIn('status', ['approved', 'taken'])
+            ->sum('days_requested');
+    }
 
     /** @return BelongsTo<Department, $this> */
     public function department(): BelongsTo

--- a/app/Models/Shop/Customer.php
+++ b/app/Models/Shop/Customer.php
@@ -54,4 +54,10 @@ class Customer extends Model
     {
         return $this->hasManyThrough(Payment::class, Order::class, 'customer_id');
     }
+
+    /** @return HasMany<DiscountCode, $this> */
+    public function discountCodes(): HasMany
+    {
+        return $this->hasMany(DiscountCode::class);
+    }
 }

--- a/app/Models/Shop/DiscountCode.php
+++ b/app/Models/Shop/DiscountCode.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Shop;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DiscountCode extends Model
+{
+    /**
+     * @var string
+     */
+    protected $table = 'discount_codes';
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'discount_percentage' => 'integer',
+    ];
+
+    /** @return BelongsTo<Customer, $this> */
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
+}

--- a/app/Models/Shop/Order.php
+++ b/app/Models/Shop/Order.php
@@ -35,11 +35,14 @@ class Order extends Model
         'shipping_price',
         'shipping_method',
         'notes',
+        'discount_applied',
     ];
 
     protected $casts = [
         'currency' => CurrencyCode::class,
         'status' => OrderStatus::class,
+        'discount_applied' => 'boolean',
+        'total_price' => 'decimal:2',
     ];
 
     /** @return MorphOne<OrderAddress, $this> */

--- a/app/Services/Shop/CustomerLoyaltyService.php
+++ b/app/Services/Shop/CustomerLoyaltyService.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Services\Shop;
+
+use App\Enums\CustomerTier;
+use App\Models\Shop\Customer;
+use App\Models\Shop\DiscountCode;
+use App\Models\Shop\Order;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class CustomerLoyaltyService
+{
+    public function getTierForOrderCount(int $count): CustomerTier
+    {
+        return CustomerTier::fromOrderCount($count);
+    }
+
+    public function getTierForCustomer(Customer $customer): CustomerTier
+    {
+        $count = $customer->orders_count ?? $customer->orders()->count();
+
+        return CustomerTier::fromOrderCount($count);
+    }
+
+    /**
+     * @return Collection<int, int>
+     */
+    public function getTop5GoldCustomerIds(): Collection
+    {
+        return Cache::remember('top_5_gold_customer_ids', now()->addMinutes(10), function (): Collection {
+            return Customer::query()
+                ->join('orders', 'customers.id', '=', 'orders.customer_id')
+                ->whereNull('orders.deleted_at')
+                ->whereNull('customers.deleted_at')
+                ->selectRaw('customers.id, count(orders.id) as orders_count')
+                ->groupBy('customers.id')
+                ->havingRaw('count(orders.id) >= 6')
+                ->orderByDesc('orders_count')
+                ->limit(5)
+                ->pluck('orders_count', 'customers.id')
+                ->keys();
+        });
+    }
+
+    public function isVipCustomer(Customer $customer): bool
+    {
+        return $this->getTop5GoldCustomerIds()->contains($customer->id);
+    }
+
+    public function applyWelcomeDiscount(Order $order): void
+    {
+        $discounted = round((float) $order->total_price * 0.9, 2);
+
+        $order->update([
+            'total_price' => $discounted,
+            'discount_applied' => true,
+        ]);
+    }
+
+    public function previewWelcomeDiscount(Order $order): float
+    {
+        return round((float) $order->total_price * 0.9, 2);
+    }
+
+    public function generateVipCode(Customer $customer, int $percentage): DiscountCode
+    {
+        $code = $this->buildVipCodeString($percentage);
+
+        return $customer->discountCodes()->create([
+            'code' => $code,
+            'discount_percentage' => $percentage,
+        ]);
+    }
+
+    public function generateWelcomeCode(Customer $customer): DiscountCode
+    {
+        $code = $this->buildWelcomeCodeString();
+
+        return $customer->discountCodes()->create([
+            'code' => $code,
+            'discount_percentage' => 10,
+        ]);
+    }
+
+    private function buildVipCodeString(int $percentage): string
+    {
+        do {
+            $suffix = strtoupper(Str::random(4));
+            $code = "VIP{$percentage}-{$suffix}";
+        } while (DiscountCode::where('code', $code)->exists());
+
+        return $code;
+    }
+
+    private function buildWelcomeCodeString(): string
+    {
+        do {
+            $suffix = strtoupper(Str::random(4));
+            $code = "WELCOME-{$suffix}";
+        } while (DiscountCode::where('code', $code)->exists());
+
+        return $code;
+    }
+}

--- a/database/factories/HR/EmployeeFactory.php
+++ b/database/factories/HR/EmployeeFactory.php
@@ -57,6 +57,12 @@ class EmployeeFactory extends Factory
                 'certification' => $this->faker->randomElement(['AWS Certified', 'PMP', 'Scrum Master', 'None']),
                 'office' => $this->faker->randomElement(['New York', 'San Francisco', 'London', 'Remote']),
             ],
+            'leave_allowance' => $this->faker->randomElement([
+                ...array_fill(0, 10, 5),
+                ...array_fill(0, 20, 10),
+                ...array_fill(0, 40, 15),
+                ...array_fill(0, 30, 20),
+            ]),
             'is_active' => $this->faker->boolean(90),
         ];
     }

--- a/database/migrations/2026_03_26_041354_add_leave_allowance_to_employees_table.php
+++ b/database/migrations/2026_03_26_041354_add_leave_allowance_to_employees_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table): void {
+            $table->unsignedSmallInteger('leave_allowance')->default(20)->after('hourly_rate');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table): void {
+            $table->dropColumn('leave_allowance');
+        });
+    }
+};

--- a/database/migrations/2026_03_26_044052_add_discount_applied_to_orders_table.php
+++ b/database/migrations/2026_03_26_044052_add_discount_applied_to_orders_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table): void {
+            $table->boolean('discount_applied')->default(false)->after('notes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table): void {
+            $table->dropColumn('discount_applied');
+        });
+    }
+};

--- a/database/migrations/2026_03_26_044052_create_discount_codes_table.php
+++ b/database/migrations/2026_03_26_044052_create_discount_codes_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('discount_codes', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('customer_id')->constrained()->cascadeOnDelete();
+            $table->string('code', 16)->unique();
+            $table->unsignedTinyInteger('discount_percentage');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('discount_codes');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,8 +18,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/resources/views/filament/pages/rewards-dashboard.blade.php
+++ b/resources/views/filament/pages/rewards-dashboard.blade.php
@@ -1,0 +1,3 @@
+<x-filament::page>
+    {{ $this->table }}
+</x-filament::page>

--- a/tests/Console/HrBirthdaysTest.php
+++ b/tests/Console/HrBirthdaysTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\HR\Department;
+use App\Models\HR\Employee;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+it('outputs a message when no upcoming birthdays exist', function () {
+    $this->artisan('hr:birthdays')
+        ->expectsOutput('No upcoming birthdays in the next 7 days.')
+        ->assertExitCode(0);
+});
+
+it('outputs a table of upcoming birthdays', function () {
+    $department = Department::factory()->create(['name' => 'Engineering']);
+
+    $employee = Employee::factory()->create([
+        'name' => 'Jane Smith',
+        'department_id' => $department->id,
+        'date_of_birth' => now()->subYears(30),
+        'is_active' => true,
+    ]);
+
+    $this->artisan('hr:birthdays')
+        ->expectsTable(
+            ['Name', 'Department', 'Birthday', 'Turning', 'Days Away'],
+            [[$employee->name, 'Engineering', now()->format('M j'), '30 yrs', 'Today!']]
+        )
+        ->assertExitCode(0);
+});
+
+it('excludes inactive employees from birthday list', function () {
+    Employee::factory()->create([
+        'date_of_birth' => now()->subYears(30),
+        'is_active' => false,
+    ]);
+
+    $this->artisan('hr:birthdays')
+        ->expectsOutput('No upcoming birthdays in the next 7 days.')
+        ->assertExitCode(0);
+});

--- a/tests/Filament/Pages/RewardsDashboardTest.php
+++ b/tests/Filament/Pages/RewardsDashboardTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use App\Filament\Pages\RewardsDashboard;
+use App\Models\Shop\Customer;
+use App\Models\Shop\Order;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Support\Facades\Cache;
+use Livewire\Livewire;
+
+it('can render the rewards dashboard page', function () {
+    $customers = Customer::factory()->count(3)->create();
+
+    Livewire::test(RewardsDashboard::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords($customers);
+});
+
+it('shows customers sorted by order count descending by default', function () {
+    $lowCustomer = Customer::factory()->create();
+    Order::factory()->count(2)->for($lowCustomer, 'customer')->create();
+
+    $highCustomer = Customer::factory()->create();
+    Order::factory()->count(10)->for($highCustomer, 'customer')->create();
+
+    $records = Livewire::test(RewardsDashboard::class)
+        ->instance()
+        ->getTableRecords();
+
+    expect($records->first()->id)->toBe($highCustomer->id);
+});
+
+it('can filter customers by Gold tier', function () {
+    $goldCustomer = Customer::factory()->create();
+    Order::factory()->count(8)->for($goldCustomer, 'customer')->create();
+
+    $silverCustomer = Customer::factory()->create();
+    Order::factory()->count(3)->for($silverCustomer, 'customer')->create();
+
+    Livewire::test(RewardsDashboard::class)
+        ->filterTable('loyalty_tier', 'gold')
+        ->assertCanSeeTableRecords([$goldCustomer])
+        ->assertCanNotSeeTableRecords([$silverCustomer]);
+});
+
+it('can filter customers by Silver tier', function () {
+    $silverCustomer = Customer::factory()->create();
+    Order::factory()->count(4)->for($silverCustomer, 'customer')->create();
+
+    $newCustomer = Customer::factory()->create();
+    Order::factory()->count(1)->for($newCustomer, 'customer')->create();
+
+    Livewire::test(RewardsDashboard::class)
+        ->filterTable('loyalty_tier', 'silver')
+        ->assertCanSeeTableRecords([$silverCustomer])
+        ->assertCanNotSeeTableRecords([$newCustomer]);
+});
+
+it('can filter customers by New tier', function () {
+    $newCustomer = Customer::factory()->create();
+    Order::factory()->count(1)->for($newCustomer, 'customer')->create();
+
+    $goldCustomer = Customer::factory()->create();
+    Order::factory()->count(9)->for($goldCustomer, 'customer')->create();
+
+    Livewire::test(RewardsDashboard::class)
+        ->filterTable('loyalty_tier', 'new')
+        ->assertCanSeeTableRecords([$newCustomer])
+        ->assertCanNotSeeTableRecords([$goldCustomer]);
+});
+
+it('reward_vip action generates a code and notifies', function () {
+    $customers = Customer::factory()->count(5)->create();
+    foreach ($customers as $c) {
+        Order::factory()->count(7)->for($c, 'customer')->create();
+    }
+
+    Cache::forget('top_5_gold_customer_ids');
+    $vipCustomer = $customers->first();
+
+    Livewire::test(RewardsDashboard::class)
+        ->callAction(TestAction::make('reward_vip')->table($vipCustomer), [
+            'discount_percentage' => 20,
+        ])
+        ->assertNotified();
+
+    expect($vipCustomer->discountCodes()->count())->toBe(1);
+    expect($vipCustomer->discountCodes()->first()->discount_percentage)->toBe(20);
+});
+
+it('reward_vip action is hidden for non-VIP customers', function () {
+    $silverCustomer = Customer::factory()->create();
+    Order::factory()->count(3)->for($silverCustomer, 'customer')->create();
+
+    Cache::forget('top_5_gold_customer_ids');
+
+    Livewire::test(RewardsDashboard::class)
+        ->assertActionHidden(TestAction::make('reward_vip')->table($silverCustomer));
+});

--- a/tests/Filament/Resources/HR/LeaveRequests/Pages/ListLeaveRequestsTest.php
+++ b/tests/Filament/Resources/HR/LeaveRequests/Pages/ListLeaveRequestsTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\LeaveStatus;
 use App\Filament\Resources\HR\LeaveRequests\Pages\ListLeaveRequests;
+use App\Models\HR\Department;
 use App\Models\HR\Employee;
 use App\Models\HR\LeaveRequest;
 use Filament\Actions\DeleteAction;
@@ -113,4 +114,131 @@ it('can bulk delete leave requests', function () {
         ->selectTableRecords($records)
         ->callAction(TestAction::make(DeleteBulkAction::class)->table()->bulk())
         ->assertNotified();
+});
+
+it('department conflict badge shows count when same-department colleagues have overlapping leave', function () {
+    $department = Department::factory()->create();
+    $employee1 = Employee::factory()->for($department)->create();
+    $employee2 = Employee::factory()->for($department)->create();
+
+    $overlap = LeaveRequest::factory()->for($employee2, 'employee')->create([
+        'status' => LeaveStatus::Approved,
+        'start_date' => '2025-08-01',
+        'end_date' => '2025-08-07',
+    ]);
+
+    $record = LeaveRequest::factory()->for($employee1, 'employee')->create([
+        'status' => LeaveStatus::Pending,
+        'start_date' => '2025-08-04',
+        'end_date' => '2025-08-06',
+    ]);
+
+    $component = Livewire::test(ListLeaveRequests::class);
+
+    $component->assertTableColumnStateSet(
+        'department_conflicts',
+        "1 other off in {$department->name}",
+        $record
+    );
+});
+
+it('department conflict badge shows pending colleagues too', function () {
+    $department = Department::factory()->create();
+    $employee1 = Employee::factory()->for($department)->create();
+    $employee2 = Employee::factory()->for($department)->create();
+    $employee3 = Employee::factory()->for($department)->create();
+
+    LeaveRequest::factory()->for($employee2, 'employee')->create([
+        'status' => LeaveStatus::Pending,
+        'start_date' => '2025-09-01',
+        'end_date' => '2025-09-05',
+    ]);
+
+    LeaveRequest::factory()->for($employee3, 'employee')->create([
+        'status' => LeaveStatus::Approved,
+        'start_date' => '2025-09-03',
+        'end_date' => '2025-09-07',
+    ]);
+
+    $record = LeaveRequest::factory()->for($employee1, 'employee')->create([
+        'status' => LeaveStatus::Pending,
+        'start_date' => '2025-09-02',
+        'end_date' => '2025-09-04',
+    ]);
+
+    $component = Livewire::test(ListLeaveRequests::class);
+
+    $component->assertTableColumnStateSet(
+        'department_conflicts',
+        "2 others off in {$department->name}",
+        $record
+    );
+});
+
+it('department conflict badge is empty when no colleagues overlap', function () {
+    $department = Department::factory()->create();
+    $employee1 = Employee::factory()->for($department)->create();
+    $employee2 = Employee::factory()->for($department)->create();
+
+    LeaveRequest::factory()->for($employee2, 'employee')->create([
+        'status' => LeaveStatus::Approved,
+        'start_date' => '2025-10-20',
+        'end_date' => '2025-10-22',
+    ]);
+
+    $record = LeaveRequest::factory()->for($employee1, 'employee')->create([
+        'status' => LeaveStatus::Pending,
+        'start_date' => '2025-11-01',
+        'end_date' => '2025-11-03',
+    ]);
+
+    Livewire::test(ListLeaveRequests::class)
+        ->assertTableColumnStateSet('department_conflicts', null, $record);
+});
+
+it('usedLeaveDaysThisYear counts approved and taken leave for current year only', function () {
+    $employee = Employee::factory()->create(['leave_allowance' => 20]);
+
+    LeaveRequest::factory()->for($employee, 'employee')->create([
+        'status' => LeaveStatus::Approved,
+        'start_date' => now()->startOfYear()->toDateString(),
+        'end_date' => now()->startOfYear()->addDays(4)->toDateString(),
+        'days_requested' => 5,
+    ]);
+
+    LeaveRequest::factory()->for($employee, 'employee')->create([
+        'status' => LeaveStatus::Taken,
+        'start_date' => now()->startOfYear()->addDays(10)->toDateString(),
+        'end_date' => now()->startOfYear()->addDays(12)->toDateString(),
+        'days_requested' => 3,
+    ]);
+
+    // Rejected leave should not count
+    LeaveRequest::factory()->for($employee, 'employee')->create([
+        'status' => LeaveStatus::Rejected,
+        'start_date' => now()->startOfYear()->addDays(20)->toDateString(),
+        'end_date' => now()->startOfYear()->addDays(22)->toDateString(),
+        'days_requested' => 4,
+    ]);
+
+    expect($employee->usedLeaveDaysThisYear())->toBe(8.0);
+});
+
+it('usedLeaveDaysThisYear returns zero when employee has no leave this year', function () {
+    $employee = Employee::factory()->create(['leave_allowance' => 20]);
+
+    expect($employee->usedLeaveDaysThisYear())->toBe(0.0);
+});
+
+it('employee is flagged as over limit when used days meets allowance', function () {
+    $employee = Employee::factory()->create(['leave_allowance' => 5]);
+
+    LeaveRequest::factory()->for($employee, 'employee')->create([
+        'status' => LeaveStatus::Approved,
+        'start_date' => now()->startOfYear()->toDateString(),
+        'end_date' => now()->startOfYear()->addDays(4)->toDateString(),
+        'days_requested' => 5,
+    ]);
+
+    expect($employee->usedLeaveDaysThisYear())->toBeGreaterThanOrEqual($employee->leave_allowance);
 });

--- a/tests/Filament/Services/Shop/CustomerLoyaltyServiceTest.php
+++ b/tests/Filament/Services/Shop/CustomerLoyaltyServiceTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Enums\CustomerTier;
+use App\Models\Shop\Customer;
+use App\Models\Shop\DiscountCode;
+use App\Models\Shop\Order;
+use App\Services\Shop\CustomerLoyaltyService;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function (): void {
+    $this->service = app(CustomerLoyaltyService::class);
+});
+
+// --- Tier logic ---
+
+it('assigns New tier to a customer with 1 order', function () {
+    expect($this->service->getTierForOrderCount(1))->toBe(CustomerTier::New);
+});
+
+it('assigns Silver tier to customers with 2 to 5 orders', function (int $count) {
+    expect($this->service->getTierForOrderCount($count))->toBe(CustomerTier::Silver);
+})->with([2, 3, 4, 5]);
+
+it('assigns Gold tier to customers with 6 or more orders', function (int $count) {
+    expect($this->service->getTierForOrderCount($count))->toBe(CustomerTier::Gold);
+})->with([6, 10, 25]);
+
+it('assigns New tier to a customer with 0 orders', function () {
+    expect($this->service->getTierForOrderCount(0))->toBe(CustomerTier::New);
+});
+
+it('getTierForCustomer uses orders_count relation', function () {
+    $customer = Customer::factory()->create();
+    Order::factory()->count(6)->for($customer, 'customer')->create();
+    $customer->loadCount('orders');
+
+    expect($this->service->getTierForCustomer($customer))->toBe(CustomerTier::Gold);
+});
+
+// --- Top 5 VIP ---
+
+it('identifies top 5 Gold customers correctly', function () {
+    $goldCustomers = Customer::factory()->count(5)->create();
+    foreach ($goldCustomers as $c) {
+        Order::factory()->count(8)->for($c, 'customer')->create();
+    }
+
+    $silver = Customer::factory()->create();
+    Order::factory()->count(3)->for($silver, 'customer')->create();
+
+    Cache::forget('top_5_gold_customer_ids');
+    $ids = $this->service->getTop5GoldCustomerIds();
+
+    expect($ids)->toHaveCount(5);
+    expect($ids->contains($silver->id))->toBeFalse();
+});
+
+it('excludes customers with fewer than 6 orders from VIP', function () {
+    $customer = Customer::factory()->create();
+    Order::factory()->count(5)->for($customer, 'customer')->create();
+
+    Cache::forget('top_5_gold_customer_ids');
+
+    expect($this->service->isVipCustomer($customer))->toBeFalse();
+});
+
+it('caps VIP list at 5 even when more Gold customers exist', function () {
+    $customers = Customer::factory()->count(8)->create();
+    foreach ($customers as $c) {
+        Order::factory()->count(7)->for($c, 'customer')->create();
+    }
+
+    Cache::forget('top_5_gold_customer_ids');
+    $ids = $this->service->getTop5GoldCustomerIds();
+
+    expect($ids)->toHaveCount(5);
+});
+
+// --- Welcome discount ---
+
+it('applies 10% discount to order total_price', function () {
+    $customer = Customer::factory()->create();
+    $order = Order::factory()->for($customer, 'customer')->create(['total_price' => 200.00]);
+
+    $this->service->applyWelcomeDiscount($order);
+
+    $order->refresh();
+    expect((float) $order->total_price)->toBe(180.00);
+    expect($order->discount_applied)->toBeTrue();
+});
+
+it('previews discounted price without saving', function () {
+    $customer = Customer::factory()->create();
+    $order = Order::factory()->for($customer, 'customer')->create(['total_price' => 100.00]);
+
+    $preview = $this->service->previewWelcomeDiscount($order);
+
+    expect($preview)->toBe(90.00);
+    $order->refresh();
+    expect((float) $order->total_price)->toBe(100.00);
+    expect($order->discount_applied)->toBeFalse();
+});
+
+// --- VIP code generation ---
+
+it('generates a VIP coupon code in the correct format', function () {
+    $customer = Customer::factory()->create();
+
+    $code = $this->service->generateVipCode($customer, 20);
+
+    expect($code)->toBeInstanceOf(DiscountCode::class);
+    expect($code->discount_percentage)->toBe(20);
+    expect($code->customer_id)->toBe($customer->id);
+    expect($code->code)->toMatch('/^VIP20-[A-Z0-9]{4}$/');
+});
+
+it('generates unique codes for each call', function () {
+    $customer = Customer::factory()->create();
+
+    $code1 = $this->service->generateVipCode($customer, 10);
+    $code2 = $this->service->generateVipCode($customer, 10);
+
+    expect($code1->code)->not->toBe($code2->code);
+});
+
+it('stores the discount code tied to the customer', function () {
+    $customer = Customer::factory()->create();
+
+    $this->service->generateVipCode($customer, 15);
+
+    expect($customer->discountCodes()->count())->toBe(1);
+    expect($customer->discountCodes()->first()->discount_percentage)->toBe(15);
+});

--- a/tests/Filament/Widgets/UpcomingBirthdaysWidgetTest.php
+++ b/tests/Filament/Widgets/UpcomingBirthdaysWidgetTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Filament\Widgets\UpcomingBirthdaysWidget;
+use App\Models\HR\Department;
+use App\Models\HR\Employee;
+use Livewire\Livewire;
+
+it('renders the upcoming birthdays widget', function () {
+    $department = Department::factory()->create();
+
+    $upcoming = Employee::factory()->count(2)->sequence(
+        ['date_of_birth' => now()->subYears(30), 'is_active' => true],
+        ['date_of_birth' => now()->addDays(5)->subYears(25), 'is_active' => true],
+    )->create(['department_id' => $department->id]);
+
+    Livewire::test(UpcomingBirthdaysWidget::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords($upcoming);
+});
+
+it('excludes employees with birthdays outside the next 7 days', function () {
+    $department = Department::factory()->create();
+
+    $outsideWindow = Employee::factory()->create([
+        'department_id' => $department->id,
+        'date_of_birth' => now()->addDays(10)->subYears(28),
+        'is_active' => true,
+    ]);
+
+    Livewire::test(UpcomingBirthdaysWidget::class)
+        ->assertOk()
+        ->assertCanNotSeeTableRecords(collect([$outsideWindow]));
+});
+
+it('excludes inactive employees', function () {
+    $department = Department::factory()->create();
+
+    $inactive = Employee::factory()->create([
+        'department_id' => $department->id,
+        'date_of_birth' => now()->subYears(22),
+        'is_active' => false,
+    ]);
+
+    Livewire::test(UpcomingBirthdaysWidget::class)
+        ->assertOk()
+        ->assertCanNotSeeTableRecords(collect([$inactive]));
+});
+
+it('shows empty state when no upcoming birthdays exist', function () {
+    Livewire::test(UpcomingBirthdaysWidget::class)
+        ->assertOk()
+        ->assertSeeText('No upcoming birthdays');
+});


### PR DESCRIPTION
## Summary

- Add `UpcomingBirthdaysWidget` to the HR dashboard showing active employees with birthdays in the next 7 days (name, department, birthday, age turning, days away)
- Add `php artisan hr:birthdays` command that prints the same data as a formatted terminal table
- Note: `date_of_birth` field already existed in the migration, model, and employee form

## Test plan

- [ ] Widget renders on the HR dashboard with no errors
- [ ] Widget correctly shows only active employees with birthdays in the next 7 days
- [ ] Widget shows empty state when no upcoming birthdays exist
- [ ] `php artisan hr:birthdays` prints a table of upcoming birthdays
- [ ] `php artisan hr:birthdays` prints a friendly message when no birthdays are upcoming
- [ ] All 7 automated tests pass: `php artisan test --compact tests/Filament/Widgets/UpcomingBirthdaysWidgetTest.php tests/Console/HrBirthdaysTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)